### PR TITLE
Switch anchor to javascript scroll

### DIFF
--- a/app/_layouts/resources.html
+++ b/app/_layouts/resources.html
@@ -43,7 +43,7 @@ The following part removes dulpicated categories and invalid categories like bla
 				<ul class="list-type-none dropdown-resources-options">
 					{% for category in categories %}
 					<li class="list-item-filter link-filter">
-            <a href="/{{page.lang}}/resources#{{category | downcase | split:' ' | join:''}}">{{category}} <span class="filter-number">(2)</span></a>
+            <a href="#" onclick="event.preventDefault();document.getElementById('{{category | downcase | split:' ' | join:''}}').scrollIntoView(true);return false;">{{category}}<span class="filter-number"></span></a>
 					</li>
 					{% endfor %}
 				</ul>


### PR DESCRIPTION
On the resources page, instead of using browser anchor functionality
to jump to the relevant category, we use javascript to scroll to
the category onclick.