### PR TITLE
Hide 'usecases' when there are none

### DIFF
--- a/app/_data/en.yml
+++ b/app/_data/en.yml
@@ -18,6 +18,7 @@
   to: to
   showing: Showing
   datasets: Datasets
+  no_use_cases: "There are currently no English use cases available."
 
   # footer
   button-github: Find Us On Github

--- a/app/_data/fa.yml
+++ b/app/_data/fa.yml
@@ -16,8 +16,9 @@
   date-title: "تاریخ"
   source: "منبع"
   to: "تا"
-  showing: مجموعه داده
-  datasets: نمایش
+  showing: "مجموعه داده"
+  datasets: "نمایش"
+  no_use_cases: "برای داده‌ها نمونه کاربرد وجود ندارد"
 
   # footer
   button-github: "ما را در گیت‌هاب پیدا کنید"

--- a/app/_includes/header.html
+++ b/app/_includes/header.html
@@ -10,8 +10,16 @@
 					<ul class="nav-list list-type-none">
             {% if page.id == 'data' %}<li class="nav-list_item active data">{% else %}<li class="nav-list_item data">{% endif %}
               <a class="nav-link" href="/{{page.lang}}/datasets/">{{lang.data}}</a></li>
-            {% if page.id == 'usecases' %}<li class="nav-list_item active usecases">{% else %}<li class="nav-list_item usecases">{% endif %}
+            {% assign counter = 0 %}
+            {% for usecase in site.usecases %}
+              {% if usecase.lang == page.lang %}
+                {% assign counter = counter | plus: 1 %}
+              {% endif %}
+            {% endfor %}
+            {% if counter > 0 %}
+              {% if page.id == 'usecases' %}<li class="nav-list_item active usecases">{% else %}<li class="nav-list_item usecases">{% endif %}
 						  <a class="nav-link" href="/{{page.lang}}/usecases/">{{lang.use_cases}}</a></li>
+            {% endif %}
             {% if page.id == 'resources' %}<li class="nav-list_item active resources">{% else %}<li class="nav-list_item resources">{% endif %}
 						  <a class="nav-link" href="/{{page.lang}}/resources/">{{lang.resources}}</a></li>
             {% if page.id == 'developers' %}<li class="nav-list_item active developers">{% else %}<li class="nav-list_item developers">{% endif %}

--- a/app/_layouts/usecases.html
+++ b/app/_layouts/usecases.html
@@ -5,34 +5,43 @@ layout: default
 <section>
 	<div class="wrapper wrapper-content">
 		<h1>{{lang.use_cases}}</h1>
-		<div class="feature-overlay">
-			{% for usecase in site.usecases %}
-				{% if usecase.featured == true %}
-					<img class="img-feature" src="/assets/graphics/{{usecase.img}}">
-					<div class="overlay-description">
-						<span class="type-category">{{lang.featured}}</span>
-						<h4><a target="_blank" class="text-link" href="{{usecase.link}}">{{usecase.title}}</a></h4>
-						<p class="width-shortened">{{usecase.description}}</p>
-						<a target="_blank" class="normal-link" href="{{usecase.link}}">{{homepage-usecase-link}}</a>
-					</div>
-				{% endif %}
-			{% endfor %}
-		</div>
-		<ul class="list-type-none">
-			{% for usecase in site.usecases %}
-				{% if usecase.featured == false %}
-					<li class="list-item-block list-item-block-sm">
-						<a target="_blank" href="{{usecase.link}}"><img class="img-feature image-usecase" src="/assets/graphics/{{usecase.img}}"></a>
-						<h5 class="header-with-description"><a target="_blank" class="text-link" href="{{usecase.link}}">{{usecase.title}}</a></h5>
-						<dl class="metadata">
-							<dt>{{lang.source}}:</dt>
-							<dd>{{usecase.source}}</dd>
-						</dl>
-						<p>{{usecase.description}}</p>
-					</li>
-				{% endif %}
-			{% endfor %}
-		</ul>
-	</div>
+    {% assign counter = 0 %}
+    {% for usecase in site.usecases %}
+      {% if usecase.lang == page.lang %}
+        {% assign counter = counter | plus: 1 %}
+      {% endif %}
+    {% endfor %}
+    {% if counter == 0 %}
+      {{lang.no_use_cases}}
+    {% endif %}
+    <div class="feature-overlay">
+      {% for usecase in site.usecases %}
+        {% if usecase.lang == page.lang and usecase.featured == true %}
+          <img class="img-feature" src="/assets/graphics/{{usecase.img}}">
+          <div class="overlay-description">
+            <span class="type-category">{{lang.featured}}</span>
+            <h4><a target="_blank" class="text-link" href="{{usecase.link}}">{{usecase.title}}</a></h4>
+            <p class="width-shortened">{{usecase.description}}</p>
+            <a target="_blank" class="normal-link" href="{{usecase.link}}">{{homepage-usecase-link}}</a>
+          </div>
+        {% endif %}
+      {% endfor %}
+    </div>
+    <ul class="list-type-none">
+      {% for usecase in site.usecases %}
+        {% if usecase.lang == page.lang and usecase.featured == false %}
+          <li class="list-item-block list-item-block-sm">
+            <a target="_blank" href="{{usecase.link}}"><img class="img-feature image-usecase" src="/assets/graphics/{{usecase.img}}"></a>
+            <h5 class="header-with-description"><a target="_blank" class="text-link" href="{{usecase.link}}">{{usecase.title}}</a></h5>
+            <dl class="metadata">
+              <dt>{{lang.source}}:</dt>
+              <dd>{{usecase.source}}</dd>
+            </dl>
+            <p>{{usecase.description}}</p>
+          </li>
+        {% endif %}
+      {% endfor %}
+    </ul>
+  </div>
 </section>
 {% include show-work.html %}

--- a/app/_usecases/0001-01-01-name1.md
+++ b/app/_usecases/0001-01-01-name1.md
@@ -7,5 +7,5 @@ description: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendiss
 link: http://developmentseed.org
 img: usecase1.jpg
 featured: no
-lang: en
+lang: fa
 ---

--- a/app/_usecases/0001-01-02-name2.md
+++ b/app/_usecases/0001-01-02-name2.md
@@ -7,5 +7,5 @@ description: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendiss
 link: http://developmentseed.org
 img: usecase2.jpg
 featured: no
-lang: en
+lang: fa
 ---

--- a/app/_usecases/0001-01-03-name3.md
+++ b/app/_usecases/0001-01-03-name3.md
@@ -7,5 +7,5 @@ description: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendiss
 link: http://developmentseed.org
 img: usecase3.jpg
 featured: no
-lang: en
+lang: fa
 ---


### PR DESCRIPTION
* Usecases tab hidden from navbar when there are no use cases in
that language
* Translating use cases from one to the other by clicking on the
language header will display a message "There are no use cases"